### PR TITLE
Now Requests Pronouns of New User

### DIFF
--- a/app.js
+++ b/app.js
@@ -24,13 +24,6 @@ const app = new App({
 
 /* Add functionality here */
 
-const app = new App({
-  signingSecret: process.env.SLACK_SIGNING_SECRET,
-  token: process.env.SLACK_BOT_TOKEN
-});
-
-/* Add functionality here */
-
 app.command('/restart', async ({ command, ack, say }) => {
   await ack();
   startTutorial(command.user_id, true)

--- a/app.js
+++ b/app.js
@@ -35,13 +35,13 @@ app.event('team_join', async body => {
 
 app.action('intro_progress', async ({ ack, body }) => {
   ack();
-  updateInteractiveMessage(body.message.ts, body.channel.id, `Hi, I'm Clippy! My job is to get you on the Slack. Do you need assistance?`)
+  updateInteractiveMessage(body.message.ts, body.channel.id, `Hi, I'm Clippy! I'm the Hack Club assistant and my job is to get you on the Slack. Do you need assistance?`)
 
   updatePushedButton(body.user.id)
   await sendMessage(body.channel.id, '...', 1000)
   await sendMessage(body.channel.id, '...', 1000)
-  await sendMessage(body.channel.id, `Excellent! I'm happy to assist you in joining Hack Club today.`, 1000)
-  await sendMessage(body.channel.id, `A few quick questions:`)
+  await sendMessage(body.channel.id, `I'll take that as a yes! I'm happy to assist you in joining Hack Club today.`, 1000)
+  await sendMessage(body.channel.id, `Just a few quick questions to get you started.`)
 
   await timeout(3000)
   await app.client.chat.postMessage({

--- a/app.js
+++ b/app.js
@@ -406,7 +406,7 @@ app.action('coc_acknowledge', async ({ ack, body }) => {
   await sendMessage(body.channel.id, `Here are a bunch of other active channels that you may be interested in:`, 10, finalTs)
   await sendMessage(body.channel.id, `<#C0JDWKJVA> <#C0NP503L7> <#C6LHL48G2> <#C0DCUUH7E> <#CA3UH038Q> <#C90686D0T> <#CCW6Q86UF> <#C1C3K2RQV> <#CCW8U2LBC> <#CDLBHGUQN> <#CDJV1CXC2> <#C14D3AQTT> <#CBX54ACPJ> <#CC78UKWAC> <#C8P6DHA3W> <#C010SJJH1PT> <#CDJMS683D> <#CDN99BE9L> <#CSHEL6LP5>`, 10, finalTs)
   if (pronouns === "They/them/theirs" || pronouns === "She/her/hers"){
-    await sendMessage(body.channel.id, `Also I think you'll love <#CFZMXJ3FB>, it's a channel where many of the women/non-binary people in Hack Club are!
+    await sendMessage(body.channel.id, `Also, check out <#CFZMXJ3FB>—it’s a channel for women/femme/non-binary people in Hack Club!`, 10, finalTs)
   }
   await completeTutorial(body.user.id)
 

--- a/app.js
+++ b/app.js
@@ -24,6 +24,13 @@ const app = new App({
 
 /* Add functionality here */
 
+const app = new App({
+  signingSecret: process.env.SLACK_SIGNING_SECRET,
+  token: process.env.SLACK_BOT_TOKEN
+});
+
+/* Add functionality here */
+
 app.command('/restart', async ({ command, ack, say }) => {
   await ack();
   startTutorial(command.user_id, true)
@@ -35,15 +42,84 @@ app.event('team_join', async body => {
 
 app.action('intro_progress', async ({ ack, body }) => {
   ack();
-  updateInteractiveMessage(body.message.ts, body.channel.id, `Hi, I'm Clippy! I'm the Hack Club assistant and my job is to get you on the Slack. Do you need assistance?`)
+  updateInteractiveMessage(body.message.ts, body.channel.id, `Hi, I'm Clippy! My job is to get you on the Slack. Do you need assistance?`)
 
   updatePushedButton(body.user.id)
-
   await sendMessage(body.channel.id, '...', 1000)
   await sendMessage(body.channel.id, '...', 1000)
-  await sendMessage(body.channel.id, `I'll take that as a yes! I'm happy to assist you in joining Hack Club today.`, 1000)
-  await sendMessage(body.channel.id, `Just a few quick questions to get you started.`)
+  await sendMessage(body.channel.id, `Excellent! I'm happy to assist you in joining Hack Club today.`, 1000)
+  await sendMessage(body.channel.id, `A few quick questions:`)
 
+  await timeout(3000)
+  await app.client.chat.postMessage({
+    token: process.env.SLACK_BOT_TOKEN,
+    channel: body.channel.id,
+    blocks: [
+      {
+        "type": "section",
+        "text": {
+          "type": "mrkdwn",
+          "text": `What are your pronouns? (how you want to be referred to by others)`
+        }
+      },
+      {
+        "type": "actions",
+        "elements": [
+          {
+            "type": "button",
+            "text": {
+              "type": "plain_text",
+              "emoji": true,
+              "text": "She/her/hers"
+            },
+            "style": "primary",
+            "action_id": "she"
+          },
+          {
+            "type": "button",
+            "text": {
+              "type": "plain_text",
+              "emoji": true,
+              "text": "He/him/his"
+            },
+            "style": "primary",
+            "action_id": "he"
+          },
+          {
+            "type": "button",
+            "text": {
+              "type": "plain_text",
+              "emoji": true,
+              "text": "They/them/theirs"
+            },
+            "style": "primary",
+            "action_id": "they"
+          },
+          {
+            "type": "button",
+            "text": {
+              "type": "plain_text",
+              "emoji": true,
+              "text": "Something else!"
+            },
+            "style": "primary",
+            "action_id": "something_else"
+          }
+        ]
+      }
+    ]
+  })
+  
+  
+  
+});
+
+app.action('she', async ({ ack, body }) => {
+  ack();
+  pronouns = "She/her/hers"
+  pronoun_1 = "She"
+  updateInteractiveMessage(body.message.ts, body.channel.id, `Awesome! Taken note of. Every profile here has a custom field for pronouns, I recommend you add yours there to let others know! <${`https://slack.com/intl/en-sg/help/articles/204092246-Edit-your-profile`}|Here is a quick tutorial.>`)
+  console.log(pronouns)
   await timeout(3000)
   await app.client.chat.postMessage({
     token: process.env.SLACK_BOT_TOKEN,
@@ -85,6 +161,111 @@ app.action('intro_progress', async ({ ack, body }) => {
   })
 });
 
+app.action('he', async ({ ack, body }) => {
+  ack();
+  pronouns = "He/him/his"
+  pronoun_1 = "He"
+  updateInteractiveMessage(body.message.ts, body.channel.id, `Awesome! Taken note of. Every profile here has a custom field for pronouns, I recommend you add yours there to let others know! <${`https://slack.com/intl/en-sg/help/articles/204092246-Edit-your-profile`}|Here is a quick tutorial.>`)
+  console.log(pronouns)
+  await timeout(3000)
+  await app.client.chat.postMessage({
+    token: process.env.SLACK_BOT_TOKEN,
+    channel: body.channel.id,
+    blocks: [
+      {
+        "type": "section",
+        "text": {
+          "type": "mrkdwn",
+          "text": `Are you currently a high school student? (it's OK if you're not)`
+        }
+      },
+      {
+        "type": "actions",
+        "elements": [
+          {
+            "type": "button",
+            "text": {
+              "type": "plain_text",
+              "emoji": true,
+              "text": "Yes"
+            },
+            "style": "primary",
+            "action_id": "hs_yes"
+          },
+          {
+            "type": "button",
+            "text": {
+              "type": "plain_text",
+              "emoji": true,
+              "text": "No"
+            },
+            "style": "danger",
+            "action_id": "hs_no"
+          }
+        ]
+      }
+    ]
+  })
+});
+
+
+app.action('they', async ({ ack, body }) => {
+  ack();
+  pronouns = "They/them/theirs"
+  pronoun_1 = "They"
+  updateInteractiveMessage(body.message.ts, body.channel.id, `Awesome! Taken note of. Every profile here has a custom field for pronouns, I recommend you add yours there to let others know! <${`https://slack.com/intl/en-sg/help/articles/204092246-Edit-your-profile`}|Here is a quick tutorial.>`)
+  console.log(pronouns)
+  await timeout(3000)
+  await app.client.chat.postMessage({
+    token: process.env.SLACK_BOT_TOKEN,
+    channel: body.channel.id,
+    blocks: [
+      {
+        "type": "section",
+        "text": {
+          "type": "mrkdwn",
+          "text": `Are you currently a high school student? (it's OK if you're not)`
+        }
+      },
+      {
+        "type": "actions",
+        "elements": [
+          {
+            "type": "button",
+            "text": {
+              "type": "plain_text",
+              "emoji": true,
+              "text": "Yes"
+            },
+            "style": "primary",
+            "action_id": "hs_yes"
+          },
+          {
+            "type": "button",
+            "text": {
+              "type": "plain_text",
+              "emoji": true,
+              "text": "No"
+            },
+            "style": "danger",
+            "action_id": "hs_no"
+          }
+        ]
+      }
+    ]
+  })
+});
+
+app.action('something_else', async ({ ack, body }) => {
+  ack();
+  
+  await sendMessage(body.channel.id, `Awesome! Could you please elaborate on how would you like us to address you in the format of They/Them/Theirs?`)
+  
+});
+
+app.action('hs-question', async ({ ack, body }) => {
+
+});
 app.action('hs_yes', async ({ ack, body }) => {
   ack();
   updateInteractiveMessage(body.message.ts, body.channel.id, 'Hack Club is a community of high schoolers, so you\'ll fit right in!')
@@ -100,7 +281,7 @@ app.action('hs_no', async ({ ack, body }) => {
 app.action('hs_acknowledge', async ({ ack, body }) => {
   ack();
   await updateInteractiveMessage(body.message.ts, body.channel.id, '👍')
-  await sendMessage(body.channel.id, `What brings you (type your answer in the chat)`)
+  await sendMessage(body.channel.id, `What brings you to the Hack Club community? (type your answer in the chat)`)
 });
 
 app.event('message', async body => {
@@ -125,10 +306,61 @@ app.event('message', async body => {
     )
     const lastBotMessage = botHistory[0].text
     const lastUserMessage = history.messages[0].text
+    
+    if (lastBotMessage.includes('Could you please elaborate')) {
+      
+      pronouns = lastUserMessage
+      pronoun_1 = lastUserMessage.slice(0, lastUserMessage.search("/"))
+      console.log(pronouns)
+      
+      await sendMessage(body.event.channel, `Thanks! Taken note of. Every profile here has a custom field for pronouns, I recommend you add yours there to let others know! <${`https://slack.com/intl/en-sg/help/articles/204092246-Edit-your-profile`}|Here is a quick tutorial.>`)
+      
+      await timeout(3000)
+      await app.client.chat.postMessage({
+        token: process.env.SLACK_BOT_TOKEN,
+        channel: body.event.channel,
+        blocks: [
+          {
+            "type": "section",
+            "text": {
+              "type": "mrkdwn",
+              "text": `Are you currently a high school student? (it's OK if you're not)`
+            }
+          },
+          {
+            "type": "actions",
+            "elements": [
+              {
+                "type": "button",
+                "text": {
+                  "type": "plain_text",
+                  "emoji": true,
+                  "text": "Yes"
+                },
+                "style": "primary",
+                "action_id": "hs_yes"
+              },
+              {
+                "type": "button",
+                "text": {
+                  "type": "plain_text",
+                  "emoji": true,
+                  "text": "No"
+                },
+                "style": "danger",
+                "action_id": "hs_no"
+              }
+            ]
+          }
+        ]
+      })
+      
+      
+    }  
 
     if (lastBotMessage.includes('What brings you')) {
       // send it to welcome-committee
-      await sendMessage('GLFAEL1SL', 'New user <@' + body.event.user + '> joined! Here\'s why they joined the Hack Club community:\n\n' + lastUserMessage + '\n\nReact to this message to take ownership on reaching out.', 10)
+      await sendMessage('C011YTBQ205', 'New user <@' + body.event.user + '> joined! Here\'s why ' + pronoun_1.toLowerCase() + ' joined the Hack Club community:\n\n' + lastUserMessage + '\n\n' + pronoun_1 + ' prefer these pronouns: '+ pronouns +  '\n\nReact to this message to take ownership on reaching out.', 10)
 
       await sendMessage(body.event.channel, `Ah, very interesting! Well, let me show you around the community.`)
       await sendMessage(body.event.channel, `You're currently on Slack, the platform our community uses. If you're familiar with Discord, you'll find that Slack feels similar.`)
@@ -182,8 +414,12 @@ app.action('coc_acknowledge', async ({ ack, body }) => {
   await sendMessage(body.channel.id, shipDesc, 10, finalTs)
   await sendMessage(body.channel.id, codeDesc, 10, finalTs)
   await sendMessage(body.channel.id, `Here are a bunch of other active channels that you may be interested in:`, 10, finalTs)
-  await sendMessage(body.channel.id, `<#C0JDWKJVA> <#C0NP503L7> <#C6LHL48G2> <#C0DCUUH7E> <#CA3UH038Q> <#C90686D0T> <#CCW6Q86UF> <#C1C3K2RQV> <#CCW8U2LBC> <#CDLBHGUQN> <#CDJV1CXC2> <#C14D3AQTT> <#CBX54ACPJ> <#CC78UKWAC> <#C8P6DHA3W> <#C010SJJH1PT> <#CDJMS683D> <#CDN99BE9L> <#CSHEL6LP5>`, 10, finalTs)
-
+  if (pronouns === "They/them/theirs" || pronouns === "She/her/hers"){
+  await sendMessage(body.channel.id, `<#C0JDWKJVA> <#C0NP503L7> <#C6LHL48G2> <#C0DCUUH7E> <#CA3UH038Q> <#C90686D0T> <#CCW6Q86UF> <#C1C3K2RQV> <#CCW8U2LBC> <#CDLBHGUQN> <#CDJV1CXC2> <#C14D3AQTT> <#CBX54ACPJ> <#CC78UKWAC> <#C8P6DHA3W> <#C010SJJH1PT> <#CDJMS683D> <#CDN99BE9L> <#CSHEL6LP5> <#CFZMXJ3FB> (an awesome channel just for girls + nb people)`, 10, finalTs)
+  }
+  else{
+   await sendMessage(body.channel.id, `<#C0JDWKJVA> <#C0NP503L7> <#C6LHL48G2> <#C0DCUUH7E> <#CA3UH038Q> <#C90686D0T> <#CCW6Q86UF> <#C1C3K2RQV> <#CCW8U2LBC> <#CDLBHGUQN> <#CDJV1CXC2> <#C14D3AQTT> <#CBX54ACPJ> <#CC78UKWAC> <#C8P6DHA3W> <#C010SJJH1PT> <#CDJMS683D> <#CDN99BE9L> <#CSHEL6LP5>`, 10, finalTs)
+  }
   await completeTutorial(body.user.id)
 
   // add user to default channels
@@ -271,73 +507,92 @@ async function sendEphemeralMessage(channel, text, user) {
 }
 
 async function startTutorial(user, restart) {
-  const islandName = await generateIslandName()
+  const islandName = await generateIslandName().catch(err => console.log(err))
   const newChannel = await app.client.conversations.create({
     token: process.env.SLACK_BOT_TOKEN,
     name: islandName.channel,
     is_private: true,
     user_ids: process.env.BOT_USER_ID
-  })
-  const channelId = newChannel.channel.id
-  console.log(`New tutorial channel created: ${channelId}`)
+  }).catch(err => console.log(err));
+  const channelId = newChannel.channel.id;
 
-  await app.client.conversations.invite({
-    token: process.env.SLACK_BOT_TOKEN,
-    channel: channelId,
-    users: user
-  })
-    .catch(err => console.log(err.data.errors))
-  await app.client.conversations.invite({
-    token: process.env.SLACK_BOT_TOKEN,
-    channel: channelId,
-    users: 'U012FPRJEVB'
-  })
-
-  await app.client.conversations.setTopic({
-    token: process.env.SLACK_OAUTH_TOKEN,
-    channel: channelId,
-    topic: `Welcome to Hack Club! :wave: Unlock the community by completing this tutorial.`
-  })
+  await app.client.conversations
+    .invite({
+      token: process.env.SLACK_BOT_TOKEN,
+      channel: channelId,
+      users: user
+    })
+    .catch(err => console.log(err.data.errors));
 
   if (restart) {
-    let record = await getUserRecord(user)
-    if (typeof record === 'undefined') {
+    let record = await getUserRecord(user);
+    if (typeof record === "undefined") {
       record = await islandTable.create({
-        'Name': user,
-        'Island Channel ID': channelId,
-        'Island Channel Name': islandName.channel,
-        'Has completed tutorial': false,
-        'Pushed first button': false
-      })
+        Name: user,
+        "Island Channel ID": channelId,
+        "Island Channel Name": islandName.channel,
+        "Has completed tutorial": false
+      });
     }
     await islandTable.update(record.id, {
-      'Island Channel ID': channelId,
-      'Island Channel Name': islandName.channel,
-      'Has completed tutorial': true,
-      'Pushed first button': false
-    })
+      "Island Channel ID": channelId,
+      "Island Channel Name": islandName.channel,
+      "Has completed tutorial": true
+    });
   } else {
     await islandTable.create({
-      'Name': user,
-      'Island Channel ID': channelId,
-      'Island Channel Name': islandName.channel,
-      'Has completed tutorial': false,
-      'Pushed first button': false
-    })
+      Name: user,
+      "Island Channel ID": channelId,
+      "Island Channel Name": islandName.channel,
+      "Has completed tutorial": false
+    });
   }
 
-  await sendSingleBlockMessage(channelId, `Hi, I'm Clippy! I'm the Hack Club assistant and my job is to get you on the Slack. Do you need assistance?`, `What the heck? Who are you?`, `intro_progress`, 10)
-  await timeout(15000)
-  let pushedButton = await hasPushedButton(user)
-  if (!pushedButton) {
-    await sendMessage(channelId, `(<@${user}> Psst—this is an intro to Hack Club that every new member completes. Unlock the community by completing it. To get started, push the button that says "What the heck? Who are you?")`, 10)
-  }
+  await sendSingleBlockMessage(
+    channelId,
+    `Hi, I'm Clippy! I'm the Hack Club assistant and my job is to get you on the Slack. Do you need assistance?`,
+    `What the heck? Who are you?`,
+    `intro_progress`,
+    10
+  );
 }
 
 async function sendSingleBlockMessage(channel, text, blockText, actionId, delay) {
   await timeout(delay || 3000)
-  await app.client.chat.postMessage({
+  let message = await app.client.chat.postMessage({
     token: process.env.SLACK_BOT_TOKEN,
+    channel: channel,
+    "blocks": [
+      {
+        "type": "section",
+        "text": {
+          "type": "mrkdwn",
+          "text": text
+        }
+      },
+      {
+        "type": "actions",
+        "elements": [
+          {
+            "type": "button",
+            "text": {
+              "type": "plain_text",
+              "text": blockText,
+              "emoji": true
+            },
+            "action_id": actionId
+          }
+        ]
+      }
+    ]
+  })
+  return message
+}
+
+async function updateSingleBlockMessage(ts, channel, text, blockText, actionId) {
+  await app.client.chat.update({
+    token: process.env.SLACK_BOT_TOKEN,
+    ts: ts,
     channel: channel,
     "blocks": [
       {
@@ -520,3 +775,4 @@ function timeout(ms) {
 
   console.log("⚡️ Bolt app is running!");
 })();
+

--- a/app.js
+++ b/app.js
@@ -256,9 +256,6 @@ app.action('something_else', async ({ ack, body }) => {
   
 });
 
-app.action('hs-question', async ({ ack, body }) => {
-
-});
 app.action('hs_yes', async ({ ack, body }) => {
   ack();
   updateInteractiveMessage(body.message.ts, body.channel.id, 'Hack Club is a community of high schoolers, so you\'ll fit right in!')
@@ -407,11 +404,9 @@ app.action('coc_acknowledge', async ({ ack, body }) => {
   await sendMessage(body.channel.id, shipDesc, 10, finalTs)
   await sendMessage(body.channel.id, codeDesc, 10, finalTs)
   await sendMessage(body.channel.id, `Here are a bunch of other active channels that you may be interested in:`, 10, finalTs)
+  await sendMessage(body.channel.id, `<#C0JDWKJVA> <#C0NP503L7> <#C6LHL48G2> <#C0DCUUH7E> <#CA3UH038Q> <#C90686D0T> <#CCW6Q86UF> <#C1C3K2RQV> <#CCW8U2LBC> <#CDLBHGUQN> <#CDJV1CXC2> <#C14D3AQTT> <#CBX54ACPJ> <#CC78UKWAC> <#C8P6DHA3W> <#C010SJJH1PT> <#CDJMS683D> <#CDN99BE9L> <#CSHEL6LP5>`, 10, finalTs)
   if (pronouns === "They/them/theirs" || pronouns === "She/her/hers"){
-  await sendMessage(body.channel.id, `<#C0JDWKJVA> <#C0NP503L7> <#C6LHL48G2> <#C0DCUUH7E> <#CA3UH038Q> <#C90686D0T> <#CCW6Q86UF> <#C1C3K2RQV> <#CCW8U2LBC> <#CDLBHGUQN> <#CDJV1CXC2> <#C14D3AQTT> <#CBX54ACPJ> <#CC78UKWAC> <#C8P6DHA3W> <#C010SJJH1PT> <#CDJMS683D> <#CDN99BE9L> <#CSHEL6LP5> <#CFZMXJ3FB> (an awesome channel just for girls + nb people)`, 10, finalTs)
-  }
-  else{
-   await sendMessage(body.channel.id, `<#C0JDWKJVA> <#C0NP503L7> <#C6LHL48G2> <#C0DCUUH7E> <#CA3UH038Q> <#C90686D0T> <#CCW6Q86UF> <#C1C3K2RQV> <#CCW8U2LBC> <#CDLBHGUQN> <#CDJV1CXC2> <#C14D3AQTT> <#CBX54ACPJ> <#CC78UKWAC> <#C8P6DHA3W> <#C010SJJH1PT> <#CDJMS683D> <#CDN99BE9L> <#CSHEL6LP5>`, 10, finalTs)
+    await sendMessage(body.channel.id, `Also I think you'll love <#CFZMXJ3FB>, it's a channel where many of the women/non-binary people in Hack Club are!
   }
   await completeTutorial(body.user.id)
 

--- a/app.js
+++ b/app.js
@@ -22,6 +22,9 @@ const app = new App({
   token: process.env.SLACK_BOT_TOKEN
 });
 
+let pronouns
+let pronoun_1
+
 /* Add functionality here */
 
 app.command('/restart', async ({ command, ack, say }) => {
@@ -35,13 +38,13 @@ app.event('team_join', async body => {
 
 app.action('intro_progress', async ({ ack, body }) => {
   ack();
-  updateInteractiveMessage(body.message.ts, body.channel.id, `Hi, I'm Clippy! I'm the Hack Club assistant and my job is to get you on the Slack. Do you need assistance?`)
+  updateInteractiveMessage(body.message.ts, body.channel.id, `Hi, I'm Clippy! My job is to get you on the Slack. Do you need assistance?`)
 
   updatePushedButton(body.user.id)
   await sendMessage(body.channel.id, '...', 1000)
   await sendMessage(body.channel.id, '...', 1000)
-  await sendMessage(body.channel.id, `I'll take that as a yes! I'm happy to assist you in joining Hack Club today.`, 1000)
-  await sendMessage(body.channel.id, `Just a few quick questions to get you started.`)
+  await sendMessage(body.channel.id, `Excellent! I'm happy to assist you in joining Hack Club today.`, 1000)
+  await sendMessage(body.channel.id, `A few quick questions:`)
 
   await timeout(3000)
   await app.client.chat.postMessage({
@@ -63,7 +66,7 @@ app.action('intro_progress', async ({ ack, body }) => {
             "text": {
               "type": "plain_text",
               "emoji": true,
-              "text": "She/her/hers"
+              "text": "she/her/hers"
             },
             "style": "primary",
             "action_id": "she"
@@ -73,7 +76,7 @@ app.action('intro_progress', async ({ ack, body }) => {
             "text": {
               "type": "plain_text",
               "emoji": true,
-              "text": "He/him/his"
+              "text": "he/him/his"
             },
             "style": "primary",
             "action_id": "he"
@@ -83,7 +86,7 @@ app.action('intro_progress', async ({ ack, body }) => {
             "text": {
               "type": "plain_text",
               "emoji": true,
-              "text": "They/them/theirs"
+              "text": "they/them/theirs"
             },
             "style": "primary",
             "action_id": "they"
@@ -93,7 +96,7 @@ app.action('intro_progress', async ({ ack, body }) => {
             "text": {
               "type": "plain_text",
               "emoji": true,
-              "text": "Something else!"
+              "text": "something else"
             },
             "style": "primary",
             "action_id": "something_else"
@@ -102,176 +105,60 @@ app.action('intro_progress', async ({ ack, body }) => {
       }
     ]
   })
-  
-  
-  
 });
 
 app.action('she', async ({ ack, body }) => {
   ack();
-  pronouns = "She/her/hers"
-  pronoun_1 = "She"
-  updateInteractiveMessage(body.message.ts, body.channel.id, `Awesome! Taken note of. Every profile here has a custom field for pronouns, I recommend you add yours there to let others know! <${`https://slack.com/intl/en-sg/help/articles/204092246-Edit-your-profile`}|Here is a quick tutorial.>`)
-  console.log(pronouns)
-  await timeout(3000)
-  await app.client.chat.postMessage({
-    token: process.env.SLACK_BOT_TOKEN,
-    channel: body.channel.id,
-    blocks: [
-      {
-        "type": "section",
-        "text": {
-          "type": "mrkdwn",
-          "text": `Are you currently a high school student? (it's OK if you're not)`
-        }
-      },
-      {
-        "type": "actions",
-        "elements": [
-          {
-            "type": "button",
-            "text": {
-              "type": "plain_text",
-              "emoji": true,
-              "text": "Yes"
-            },
-            "style": "primary",
-            "action_id": "hs_yes"
-          },
-          {
-            "type": "button",
-            "text": {
-              "type": "plain_text",
-              "emoji": true,
-              "text": "No"
-            },
-            "style": "danger",
-            "action_id": "hs_no"
-          }
-        ]
-      }
-    ]
-  })
+  await setPronouns(body.user.id, 'she/her/hers', 'she')
+  updateSingleBlockMessage(body.message.ts, body.channel.id, `What are your pronouns? (how you want to be referred to by others)`, `she/her/hers`, `mimmiggie`)
+  await sendMessage(body.channel.id, `:heart: Every profile here has a custom field for pronouns—I recommend adding yours there to let others know! <${`https://slack.com/intl/en-sg/help/articles/204092246-Edit-your-profile`}|Here's a quick tutorial.>`)
+  sendHsQuestion(body.channel.id)
 });
 
 app.action('he', async ({ ack, body }) => {
   ack();
-  pronouns = "He/him/his"
-  pronoun_1 = "He"
-  updateInteractiveMessage(body.message.ts, body.channel.id, `Awesome! Taken note of. Every profile here has a custom field for pronouns, I recommend you add yours there to let others know! <${`https://slack.com/intl/en-sg/help/articles/204092246-Edit-your-profile`}|Here is a quick tutorial.>`)
-  console.log(pronouns)
-  await timeout(3000)
-  await app.client.chat.postMessage({
-    token: process.env.SLACK_BOT_TOKEN,
-    channel: body.channel.id,
-    blocks: [
-      {
-        "type": "section",
-        "text": {
-          "type": "mrkdwn",
-          "text": `Are you currently a high school student? (it's OK if you're not)`
-        }
-      },
-      {
-        "type": "actions",
-        "elements": [
-          {
-            "type": "button",
-            "text": {
-              "type": "plain_text",
-              "emoji": true,
-              "text": "Yes"
-            },
-            "style": "primary",
-            "action_id": "hs_yes"
-          },
-          {
-            "type": "button",
-            "text": {
-              "type": "plain_text",
-              "emoji": true,
-              "text": "No"
-            },
-            "style": "danger",
-            "action_id": "hs_no"
-          }
-        ]
-      }
-    ]
-  })
+  await setPronouns(body.user.id, 'he/him/his', 'he')
+  updateSingleBlockMessage(body.message.ts, body.channel.id, `What are your pronouns? (how you want to be referred to by others)`, `he/him/his`, `mimmiggie`)
+  await sendMessage(body.channel.id, `:heart: Every profile here has a custom field for pronouns—I recommend adding yours there to let others know! <${`https://slack.com/intl/en-sg/help/articles/204092246-Edit-your-profile`}|Here's a quick tutorial.>`)
+  sendHsQuestion(body.channel.id)
 });
 
 
 app.action('they', async ({ ack, body }) => {
   ack();
-  pronouns = "They/them/theirs"
-  pronoun_1 = "They"
-  updateInteractiveMessage(body.message.ts, body.channel.id, `Awesome! Taken note of. Every profile here has a custom field for pronouns, I recommend you add yours there to let others know! <${`https://slack.com/intl/en-sg/help/articles/204092246-Edit-your-profile`}|Here is a quick tutorial.>`)
-  console.log(pronouns)
-  await timeout(3000)
-  await app.client.chat.postMessage({
-    token: process.env.SLACK_BOT_TOKEN,
-    channel: body.channel.id,
-    blocks: [
-      {
-        "type": "section",
-        "text": {
-          "type": "mrkdwn",
-          "text": `Are you currently a high school student? (it's OK if you're not)`
-        }
-      },
-      {
-        "type": "actions",
-        "elements": [
-          {
-            "type": "button",
-            "text": {
-              "type": "plain_text",
-              "emoji": true,
-              "text": "Yes"
-            },
-            "style": "primary",
-            "action_id": "hs_yes"
-          },
-          {
-            "type": "button",
-            "text": {
-              "type": "plain_text",
-              "emoji": true,
-              "text": "No"
-            },
-            "style": "danger",
-            "action_id": "hs_no"
-          }
-        ]
-      }
-    ]
-  })
+  await setPronouns(body.user.id, 'they/them/theirs', 'they')
+  updateSingleBlockMessage(body.message.ts, body.channel.id, `What are your pronouns? (how you want to be referred to by others)`, `they/them/theirs`, `mimmiggie`)
+  await sendMessage(body.channel.id, `:heart: Every profile here has a custom field for pronouns—I recommend adding yours there to let others know! <${`https://slack.com/intl/en-sg/help/articles/204092246-Edit-your-profile`}|Here's a quick tutorial.>`)
+  sendHsQuestion(body.channel.id)
 });
 
 app.action('something_else', async ({ ack, body }) => {
   ack();
-  
-  await sendMessage(body.channel.id, `Awesome! Could you please elaborate on how would you like us to address you in the format of They/Them/Theirs?`)
-  
+  await sendMessage(body.channel.id, `What are your preferred pronouns? (Type your answer in chat)`)
 });
 
 app.action('hs_yes', async ({ ack, body }) => {
   ack();
-  updateInteractiveMessage(body.message.ts, body.channel.id, 'Hack Club is a community of high schoolers, so you\'ll fit right in!')
+  updateSingleBlockMessage(body.message.ts, body.channel.id, `Are you currently a high school student? (it's OK if you're not)`, `Yes`, `mimmiggie`)
+  await sendMessage(body.channel.id, 'Hack Club is a community of high schoolers, so you\'ll fit right in!')
   await sendMessage(body.channel.id, `What brings you to the Hack Club community? (Type your answer in the chat)`)
 });
 
 app.action('hs_no', async ({ ack, body }) => {
   ack();
-  await updateInteractiveMessage(body.message.ts, body.channel.id, 'Just a heads-up: Hack Club is a community of high schoolers, not a community of professional developers. You will likely still find a home here if you are in college, but if you\'re older than that, you may find yourself lost here.')
+  updateSingleBlockMessage(body.message.ts, body.channel.id, `Are you currently a high school student? (it's OK if you're not)`, `No`, `mimmiggie`)
+  await sendMessage(body.channel.id, 'Just a heads-up: Hack Club is a community of high schoolers, not a community of professional developers. You will likely still find a home here if you are in college, but if you\'re older than that, you may find yourself lost here.')
   await sendSingleBlockMessage(body.channel.id, 'If you understand this and still want to continue on, click the 👍 below.', '👍', 'hs_acknowledge')
 });
 
 app.action('hs_acknowledge', async ({ ack, body }) => {
   ack();
   await updateInteractiveMessage(body.message.ts, body.channel.id, '👍')
-  await sendMessage(body.channel.id, `What brings you to the Hack Club community? (type your answer in the chat)`)
+  await sendMessage(body.channel.id, `What brings you to the Hack Club community? (Type your answer in the chat)`)
+});
+
+app.action('mimmiggie', async ({ ack, body }) => {
+  ack();
 });
 
 app.event('message', async body => {
@@ -296,65 +183,28 @@ app.event('message', async body => {
     )
     const lastBotMessage = botHistory[0].text
     const lastUserMessage = history.messages[0].text
-    
-    if (lastBotMessage.includes('Could you please elaborate')) {
-      
-      pronouns = lastUserMessage
-      pronoun_1 = lastUserMessage.slice(0, lastUserMessage.search("/"))
-      console.log(pronouns)
-      
-      await sendMessage(body.event.channel, `Thanks! Taken note of. Every profile here has a custom field for pronouns, I recommend you add yours there to let others know! <${`https://slack.com/intl/en-sg/help/articles/204092246-Edit-your-profile`}|Here is a quick tutorial.>`)
-      
-      await timeout(3000)
-      await app.client.chat.postMessage({
-        token: process.env.SLACK_BOT_TOKEN,
-        channel: body.event.channel,
-        blocks: [
-          {
-            "type": "section",
-            "text": {
-              "type": "mrkdwn",
-              "text": `Are you currently a high school student? (it's OK if you're not)`
-            }
-          },
-          {
-            "type": "actions",
-            "elements": [
-              {
-                "type": "button",
-                "text": {
-                  "type": "plain_text",
-                  "emoji": true,
-                  "text": "Yes"
-                },
-                "style": "primary",
-                "action_id": "hs_yes"
-              },
-              {
-                "type": "button",
-                "text": {
-                  "type": "plain_text",
-                  "emoji": true,
-                  "text": "No"
-                },
-                "style": "danger",
-                "action_id": "hs_no"
-              }
-            ]
-          }
-        ]
-      })
-      
-      
-    }  
+
+    if (lastBotMessage.includes('What are your preferred pronouns')) {
+
+      let pronouns = lastUserMessage
+      let pronoun1 = lastUserMessage.slice(0, lastUserMessage.search("/"))
+      await setPronouns(body.event.user, pronouns, pronoun1.toLowerCase())
+
+      await sendMessage(body.event.channel, `:heart: Every profile here has a custom field for pronouns—I recommend adding yours there to let others know! <${`https://slack.com/intl/en-sg/help/articles/204092246-Edit-your-profile`}|Here's a quick tutorial.>`)
+      await sendHsQuestion(body.event.channel)
+    }
 
     if (lastBotMessage.includes('What brings you')) {
       // send it to welcome-committee
-      await sendMessage('GLFAEL1SL', 'New user <@' + body.event.user + '> joined! Here\'s why ' + pronoun_1.toLowerCase() + ' joined the Hack Club community:\n\n' + lastUserMessage + '\n\n' + pronoun_1 + ' prefer these pronouns: '+ pronouns +  '\n\nReact to this message to take ownership on reaching out.', 10)
+      let userPronouns = await getPronouns(body.event.user)
+      let pronouns = userPronouns.pronouns
+      let pronoun1 = userPronouns.pronoun1
+
+      await sendMessage('GLFAEL1SL', 'New user <@' + body.event.user + '> (' + pronouns + ') joined! Here\'s why ' + pronoun1 + ' joined the Hack Club community:\n\n' + lastUserMessage + '\n\nReact to this message to take ownership on reaching out.', 10)
 
       await sendMessage(body.event.channel, `Ah, very interesting! Well, let me show you around the community.`)
-      await sendMessage(body.event.channel, `You're currently on Slack, the platform our community uses. If you're familiar with Discord, you'll find that Slack feels similar.`)
-      await sendMessage(body.event.channel, `Slack is organized into "channels", and each channel includes discussion about its own topic. We have _hundreds_ of channels, covering everything from game development and web design to photography and cooking. I'll show you a few of my favorites in a minute.`, 5000)
+      await sendMessage(body.event.channel, `You're currently on Slack, the platform our community uses. It's like Discord, but better.`)
+      await sendMessage(body.event.channel, `Slack is organized into "channels". We have _hundreds_ of channels in our Slack, covering everything from <#C6LHL48G2> and <#C0EA9S0A0> to <#CBX54ACPJ> and <#C010SJJH1PT>. I'll show you a few of my favorites in a minute.`, 5000)
       await sendMessage(body.event.channel, `I just invited you to your first channel, <#C75M7C0SY>. Join by clicking on it in your sidebar, and introduce yourself to the community.`, 5000)
 
       // add user to #welcome
@@ -405,9 +255,11 @@ app.action('coc_acknowledge', async ({ ack, body }) => {
   await sendMessage(body.channel.id, codeDesc, 10, finalTs)
   await sendMessage(body.channel.id, `Here are a bunch of other active channels that you may be interested in:`, 10, finalTs)
   await sendMessage(body.channel.id, `<#C0JDWKJVA> <#C0NP503L7> <#C6LHL48G2> <#C0DCUUH7E> <#CA3UH038Q> <#C90686D0T> <#CCW6Q86UF> <#C1C3K2RQV> <#CCW8U2LBC> <#CDLBHGUQN> <#CDJV1CXC2> <#C14D3AQTT> <#CBX54ACPJ> <#CC78UKWAC> <#C8P6DHA3W> <#C010SJJH1PT> <#CDJMS683D> <#CDN99BE9L> <#CSHEL6LP5>`, 10, finalTs)
-  if (pronouns === "They/them/theirs" || pronouns === "She/her/hers"){
-    await sendMessage(body.channel.id, `Also, check out <#CFZMXJ3FB>—it’s a channel for women/femme/non-binary people in Hack Club!`, 10, finalTs)
+
+  if (pronouns === "they/them/theirs" || pronouns === "she/her/hers") {
+    await sendMessage(body.channel.id, `Also, check out <#CFZMXJ3FB>—it’s a channel for women/femme/non-binary people in Hack Club!`, 1000)
   }
+
   await completeTutorial(body.user.id)
 
   // add user to default channels
@@ -468,9 +320,54 @@ app.event('member_joined_channel', async body => {
       channel: body.event.channel,
       user: body.event.user
     })
-    await sendMessage(body.event.user, `It looks like you tried to join <#${body.event.channel}>. You can't join any channels yet—I need to finish helping you join the community first.`, 10)
+    let islandId = getIslandId(body.event.user)
+    let islandName = getIslandName(body.event.user)
+    await sendEphemeralMessage(islandId, `<@${body.event.user} It looks like you tried to join <#${body.event.channel}>. You can't join any channels yet—I need to finish helping you join the community first.`, body.event.user)
+    await sendEphemeralMessage(body.event.channel, `<@${body.event.user} It looks like you tried to join <#${body.event.channel}>. You can't join any channels yet—I need to finish helping you join the community first. Head back over to <${`https://hackclub.slack.com/archives/${islandId}`}|#${islandName}> to unlock the rest of the community.`, body.event.user)
   }
 });
+
+async function sendHsQuestion(channel) {
+  await timeout(3000)
+  await app.client.chat.postMessage({
+    token: process.env.SLACK_BOT_TOKEN,
+    channel: channel,
+    blocks: [
+      {
+        "type": "section",
+        "text": {
+          "type": "mrkdwn",
+          "text": `Are you currently a high school student? (it's OK if you're not)`
+        }
+      },
+      {
+        "type": "actions",
+        "elements": [
+          {
+            "type": "button",
+            "text": {
+              "type": "plain_text",
+              "emoji": true,
+              "text": "Yes"
+            },
+            "style": "primary",
+            "action_id": "hs_yes"
+          },
+          {
+            "type": "button",
+            "text": {
+              "type": "plain_text",
+              "emoji": true,
+              "text": "No"
+            },
+            "style": "danger",
+            "action_id": "hs_no"
+          }
+        ]
+      }
+    ]
+  })
+}
 
 async function sendMessage(channel, text, delay, ts, unfurl) {
   await timeout(delay || 3000)
@@ -550,18 +447,52 @@ async function startTutorial(user, restart) {
     })
   }
 
-  await sendSingleBlockMessage(channelId, `Hi, I'm Clippy! I'm the Hack Club assistant and my job is to get you on the Slack. Do you need assistance?`, `What the heck? Who are you?`, `intro_progress`, 10)
-  await timeout(15000)
+  let firstMessage = await sendSingleBlockMessage(channelId, `Hi, I'm Clippy! My job is to get you on the Slack. Do you need assistance?`, `What the heck? Who are you?`, `intro_progress`, 10)
+
+  await timeout(30000)
   let pushedButton = await hasPushedButton(user)
   if (!pushedButton) {
-    await sendMessage(channelId, `(<@${user}> Psst—this is an intro to Hack Club that every new member completes. Unlock the community by completing it. To get started, push the button that says "What the heck? Who are you?")`, 10)
+    await sendMessage(channelId, `(<@${user}> Psst—every new member completes this intro to unlock the Hack Club community. Hit the button above to begin :star2:)`, 10)
+    await updateSingleBlockMessage(firstMessage.message.ts, channelId, `Hi, I'm Clippy! My job is to get you on the Slack. Do you need assistance?`, `What the heck? Who are you? 🌟`, `intro_progress`)
   }
 }
 
 async function sendSingleBlockMessage(channel, text, blockText, actionId, delay) {
   await timeout(delay || 3000)
-  await app.client.chat.postMessage({
+  let message = await app.client.chat.postMessage({
     token: process.env.SLACK_BOT_TOKEN,
+    channel: channel,
+    "blocks": [
+      {
+        "type": "section",
+        "text": {
+          "type": "mrkdwn",
+          "text": text
+        }
+      },
+      {
+        "type": "actions",
+        "elements": [
+          {
+            "type": "button",
+            "text": {
+              "type": "plain_text",
+              "text": blockText,
+              "emoji": true
+            },
+            "action_id": actionId
+          }
+        ]
+      }
+    ]
+  })
+  return message
+}
+
+async function updateSingleBlockMessage(ts, channel, text, blockText, actionId) {
+  await app.client.chat.update({
+    token: process.env.SLACK_BOT_TOKEN,
+    ts: ts,
     channel: channel,
     "blocks": [
       {
@@ -619,6 +550,27 @@ async function inviteUserToChannel(user, channel) {
       console.log(`${user} is already in ${channel}—skipping this step...`)
     }
   })
+}
+
+async function setPronouns(userId, pronouns, pronoun1) {
+  let record = await getUserRecord(userId)
+  console.log(record)
+  let recId = record.id
+
+  islandTable.update(recId, {
+    'Pronouns': pronouns,
+    'Pronoun 1': pronoun1
+  })
+}
+
+async function getPronouns(userId) {
+  let userRecord = await getUserRecord(userId)
+  let pronouns = userRecord.fields['Pronouns']
+  let pronoun1 = userRecord.fields['Pronoun 1']
+  return {
+    pronouns: pronouns,
+    pronoun1: pronoun1
+  }
 }
 
 async function updatePushedButton(userId) {


### PR DESCRIPTION
Added stuff:

- Clippy now asks What are your pronouns? (how you want to be referred to by others)

![Screen Shot 2020-04-30 at 9 02 29 PM](https://user-images.githubusercontent.com/39828164/80713391-f0e7df00-8b25-11ea-8346-d9ef1f4f2437.png)

- Clippy responds to those that choose Something Else with "Awesome! Could you please elaborate on how would you like us to address you in the format of They/Them/Theirs?"

- Once it has all the details it says "Awesome! Taken note of. Every profile here has a custom field for pronouns, I recommend you add yours there to let others know! Here is a quick tutorial." or  "Great! Taken note of. Every profile here has a custom field for pronouns, I recommend you add yours there to let others know! Here is a quick tutorial." The tutorial link works in slack links here: https://api.slack.com/reference/block-kit/block-elements

- When sending to welcome committee it uses their pronouns! Even those who chose something else (that's why we needed the format).

- It also says their pronouns in the welcome committee message

![Screen Shot 2020-04-30 at 9 06 30 PM](https://user-images.githubusercontent.com/39828164/80713730-7cfa0680-8b26-11ea-9e2a-4f021939e795.png)

- At the end if they choose She or They it links them to the #orpheus-legion channel
