### PR TITLE
Add /clippy-channel command

### DIFF
--- a/app.js
+++ b/app.js
@@ -63,6 +63,25 @@ app.command('/restart', async ({ command, ack }) => {
   }
 })
 
+app.command('/clippy-channel', async ({ command, ack, respond }) => {
+  await ack()
+  if (command.text === '') {
+    await respond({
+      text: `Usage: \`/clippy-channel @username\``,
+      response_type: 'ephemeral'
+    })
+  } else {
+    const userId = command.text.split(' ')[0].split('|')[0].substring(2)
+    console.log('user id', userId)
+    const userRecord = await getUserRecord(userId)
+    
+    await respond({
+      text: `<@${userId}>'s Clippy channel is \`${userRecord.fields['Island Channel Name']}\`. \`https://app.slack.com/client/T0266FRGM/${userRecord.fields['Island Channel ID']}\``,
+      response_type: 'ephemeral'
+    })
+  }
+})
+
 app.event('message', async body => {
   const defaultAdds = ['C0C78SG9L', 'C0EA9S0A0', 'C0266FRGV', 'C0M8PUPU6', 'C75M7C0SY', 'C74HZS5A5']
   


### PR DESCRIPTION
I get a lot of DMs asking me how to unlock the community because they're multi-channel guests. Usually I get their user ID with `/lookup`, go into the Tutorial Island Airtable, find the name of their Clippy channel ID, and then go back and tell them. This command does all that work for me, and it also links the channel so that I can directly go to it with Clippy Admin if they're having trouble.

At the time I'm making this, about 100 members of Hack Club KMEA are joining the Slack, so DON'T MERGE until they finish joining so that their Clippy tutorials aren't interrupted.