### PR TITLE
Mention /sup in default flow

### DIFF
--- a/flows/default.js
+++ b/flows/default.js
@@ -212,7 +212,7 @@ const loadFlow = (app) => {
         await sendMessage(app, body.event.channel, `...it sounds like a Slack ping!`, 2000)
         await sendMessage(app, body.event.channel, `Oh!!! It looks like you're already in a channel! <#C0266FRGV>, the hangout channel for Hack Club members.`)
         await sendMessage(app, body.event.channel, `Try clicking the red :ping: on your sidebar to the left :eyes:`)
-        await sendMessage(app, body.event.channel, `<@${body.event.user}> As I was saying before I got distracted, we have _hundreds_ of these "channels" in the community, covering every topic you can think of, from \`#gamedev\` and \`#code\` to \`#photography\` and \`#cooking\`. We have nearly 1,000 weekly active members on here—wowee, that's a lot!!!`, 10000)
+        await sendMessage(app, body.event.channel, `<@${body.event.user}> As I was saying before I got distracted, we have _hundreds_ of these "channels" in the community, covering every topic you can think of, from \`#gamedev\` and \`#code\` to \`#photography\` and \`#cooking\`. We have nearly 1,000 weekly active members on here—wowee, that's a lot!!! You can run \`/sup\` at any time to see what the most active channels are in the last 2 hours.`, 10000)
         await sendMessage(app, body.event.channel, `Want to be invited to another channel?`, 5000)
 
         const welcomeChannel = 'C75M7C0SY';

--- a/flows/default.js
+++ b/flows/default.js
@@ -212,7 +212,7 @@ const loadFlow = (app) => {
         await sendMessage(app, body.event.channel, `...it sounds like a Slack ping!`, 2000)
         await sendMessage(app, body.event.channel, `Oh!!! It looks like you're already in a channel! <#C0266FRGV>, the hangout channel for Hack Club members.`)
         await sendMessage(app, body.event.channel, `Try clicking the red :ping: on your sidebar to the left :eyes:`)
-        await sendMessage(app, body.event.channel, `<@${body.event.user}> As I was saying before I got distracted, we have _hundreds_ of these "channels" in the community, covering every topic you can think of, from \`#gamedev\` and \`#code\` to \`#photography\` and \`#cooking\`. We have nearly 1,000 weekly active members on here—wowee, that's a lot!!! You can run \`/sup\` at any time to see what the most active channels are in the last 2 hours.`, 10000)
+        await sendMessage(app, body.event.channel, `<@${body.event.user}> As I was saying before I got distracted, we have _hundreds_ of these "channels" in the community, covering every topic you can think of, from \`#gamedev\` and \`#code\` to \`#photography\` and \`#cooking\`. We have nearly 1,000 weekly active members on here—wowee, that's a lot!!! Our friend and resident log-wrangler <@U01S7UUCB89> can help you find channels to join - just run \`/sup\` at any time to see what the most active channels are in the last 2 hours.`, 10000)
         await sendMessage(app, body.event.channel, `Want to be invited to another channel?`, 5000)
 
         const welcomeChannel = 'C75M7C0SY';

--- a/flows/default.js
+++ b/flows/default.js
@@ -224,8 +224,8 @@ const loadFlow = (app) => {
               await fetch("https://streamboot-bot.herokuapp.com/api/top/channels")
           ).json();
           const topChannelIds = res.map((c) => c.channel_id)
-          // #bot-spam-for-deer, #cdn, #spam, #bot-spam
-          const channelRecBlocklist = ["C020LT3UCBW", "C016DEDUL87", "C141CCD2Q", "C0P5NE354"]
+          // #bot-spam-for-deer, #cdn, #spam, #bot-spam, #orpheus-internals
+          const channelRecBlocklist = ["C020LT3UCBW", "C016DEDUL87", "C141CCD2Q", "C0P5NE354", "CLU651WHY"]
           const channelBlocks = []
           let max = 4
           for (let i = 0; i < max; i++) {

--- a/utils/intros.js
+++ b/utils/intros.js
@@ -3,7 +3,7 @@ const defaultIntro = [
     "type": "section",
     "text": {
       "type": "mrkdwn",
-      "text": `Hi there, I'm Clippy! It looks like you want join the Hack Club community. Before you unlock it, I need to show you around for a minute! Could you please click that button :point_down: so we can get this show on the road?`
+      "text": `Hi there, I'm Clippy! It looks like you want to join the Hack Club community. Before you unlock it, I need to show you around for a minute! Could you please click that button :point_down: so we can get this show on the road?`
     }
   },
   {
@@ -28,7 +28,7 @@ const som = [
     "type": "section",
     "text": {
       "type": "mrkdwn",
-      "text": `Hi there, I'm Clippy! It looks like you want join the Hack Club community. Before you unlock it, I need to show you around for a minute! Could you please click that button :point_down: so we can get this show on the road?`
+      "text": `Hi there, I'm Clippy! It looks like you want to join the Hack Club community. Before you unlock it, I need to show you around for a minute! Could you please click that button :point_down: so we can get this show on the road?`
     }
   },
   {


### PR DESCRIPTION
This PR makes a small change to the default onboarding flow and mentions the `/sup` command to discover the most active channels in the Slack. I was also thinking that maybe we could automatically add new people to the top 2-4 most active channels that aren't already default adds, but I'm not sure how to pull that from Paul Bunyan.